### PR TITLE
Use grouped dependabot updates and change to Monday

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,11 +3,19 @@ version: 2
 updates:
 - package-ecosystem: pip
   directory: /
+  groups:
+    deps:
+      patterns:
+        - "*"
   schedule:
     interval: weekly
-    day: "saturday"
+    day: "monday"
 - package-ecosystem: github-actions
   directory: /
+  groups:
+    deps:
+      patterns:
+        - "*"
   schedule:
     interval: weekly
-    day: "saturday"
+    day: "monday"


### PR DESCRIPTION
Deps updates don't break stuff that often and one PR will easier to manage most of the time.